### PR TITLE
Fix product display by computing root path at load

### DIFF
--- a/js/utils/detalle-producto.js
+++ b/js/utils/detalle-producto.js
@@ -1,9 +1,11 @@
+const scriptSrc = document.currentScript?.src || '';
+const rootPath = scriptSrc.split('/js/utils')[0];
+
 function renderProductDetail() {
     const params = new URLSearchParams(window.location.search);
     const id = parseInt(params.get('id'), 10);
     const product = products.find(p => p.id === id) || products[0];
     if (!product) return;
-    const rootPath = document.currentScript.src.split('/js/utils')[0];
 
     const imgEl = document.getElementById('product-image');
     const nameEl = document.getElementById('product-name');

--- a/js/utils/index.js
+++ b/js/utils/index.js
@@ -1,7 +1,9 @@
+const scriptSrc = document.currentScript?.src || '';
+const rootPath = scriptSrc.split('/js/utils')[0];
+
 function renderFeaturedProducts() {
     const container = document.getElementById('featured-products');
     if (!container) return;
-    const rootPath = document.currentScript.src.split('/js/utils')[0];
 
     const featuredProducts = products.slice(0, 8);
 

--- a/js/utils/productos.js
+++ b/js/utils/productos.js
@@ -1,7 +1,9 @@
+const scriptSrc = document.currentScript?.src || '';
+const rootPath = scriptSrc.split('/js/utils')[0];
+
 function renderProducts() {
     const container = document.getElementById('product-list');
     if (!container) return;
-    const rootPath = document.currentScript.src.split('/js/utils')[0];
 
     products.forEach(product => {
         const col = document.createElement('div');


### PR DESCRIPTION
## Summary
- Ensure product rendering scripts compute root path at load time to avoid `document.currentScript` being null
- Apply fix across index, product list, and product detail pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2abe717948326822fe05c5bab1610