### PR TITLE
Agregar stock y botones en páginas de administración

### DIFF
--- a/html_administrador/productos.html
+++ b/html_administrador/productos.html
@@ -32,6 +32,7 @@
                     <th>Categoría</th>
                     <th>Nombre</th>
                     <th>Precio</th>
+                    <th>Stock</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -40,88 +41,81 @@
                     <td>Juegos de Mesa</td>
                     <td>Catan</td>
                     <td>$29.990 CLP</td>
+                    <td>15</td>
                 </tr>
                 <tr>
                     <td>JM002</td>
                     <td>Juegos de Mesa</td>
                     <td>Carcassonne</td>
                     <td>$24.990 CLP</td>
+                    <td>8</td>
                 </tr>
                 <tr>
                     <td>AC001</td>
                     <td>Accesorios</td>
                     <td>Controlador Inalámbrico Xbox Series X</td>
                     <td>$59.990 CLP</td>
+                    <td>20</td>
                 </tr>
                 <tr>
                     <td>AC002</td>
                     <td>Accesorios</td>
                     <td>Auriculares Gamer HyperX Cloud II</td>
                     <td>$79.990 CLP</td>
+                    <td>5</td>
                 </tr>
                 <tr>
                     <td>CO001</td>
                     <td>Consolas</td>
                     <td>PlayStation 5</td>
                     <td>$549.990 CLP</td>
+                    <td>12</td>
                 </tr>
                 <tr>
                     <td>CG001</td>
                     <td>Computadores Gamers</td>
                     <td>PC Gamer ASUS ROG Strix</td>
                     <td>$1.299.990 CLP</td>
+                    <td>7</td>
                 </tr>
                 <tr>
                     <td>SG001</td>
                     <td>Sillas Gamers</td>
                     <td>Silla Gamer Secretlab Titan</td>
                     <td>$349.990 CLP</td>
+                    <td>10</td>
                 </tr>
                 <tr>
                     <td>MS001</td>
                     <td>Mouse</td>
                     <td>Mouse Gamer Logitech G502 HERO</td>
                     <td>$49.990 CLP</td>
+                    <td>25</td>
                 </tr>
                 <tr>
                     <td>MP001</td>
                     <td>Mousepad</td>
                     <td>Mousepad Razer Goliathus Extended Chroma</td>
                     <td>$29.990 CLP</td>
+                    <td>18</td>
                 </tr>
                 <tr>
                     <td>PP001</td>
                     <td>Poleras Personalizadas</td>
                     <td>Polera Gamer Personalizada 'Level-Up'</td>
                     <td>$14.990 CLP</td>
+                    <td>30</td>
                 </tr>
                 </tbody>
             </table>
         </div>
-        <h2 class="mt-4">Agregar producto</h2>
-        <form id="product-form" class="row g-3">
-            <div class="col-md-3"><input type="text" id="codigo" class="form-control" placeholder="Código" required></div>
-            <div class="col-md-3"><input type="text" id="categoria" class="form-control" placeholder="Categoría" required></div>
-            <div class="col-md-3"><input type="text" id="nombre" class="form-control" placeholder="Nombre" required></div>
-            <div class="col-md-3"><input type="text" id="precio" class="form-control" placeholder="Precio" required></div>
-            <div class="col-12"><button class="btn btn-primary" type="submit">Agregar</button></div>
-        </form>
+        <div class="mt-3">
+            <button class="btn btn-secondary me-2" type="button">Editar producto</button>
+            <button class="btn btn-primary me-2" type="button">Agregar producto</button>
+            <button class="btn btn-info" type="button">Mostrar producto</button>
+        </div>
     </main>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-<script>
-    document.getElementById('product-form').addEventListener('submit', function(e) {
-        e.preventDefault();
-        const tbody = document.querySelector('table tbody');
-        const code = document.getElementById('codigo').value;
-        const category = document.getElementById('categoria').value;
-        const name = document.getElementById('nombre').value;
-        const price = document.getElementById('precio').value;
-        const row = document.createElement('tr');
-        row.innerHTML = `<td>${code}</td><td>${category}</td><td>${name}</td><td>${price}</td>`;
-        tbody.appendChild(row);
-        this.reset();
-    });
-</script>
 </body>
 </html>

--- a/html_administrador/usuarios.html
+++ b/html_administrador/usuarios.html
@@ -37,27 +37,56 @@
                 </tbody>
             </table>
         </div>
-        <h2 class="mt-4">Agregar usuario</h2>
-        <form id="user-form" class="row g-3">
-            <div class="col-md-2"><input type="text" id="user-id" class="form-control" placeholder="ID" required></div>
-            <div class="col-md-5"><input type="text" id="user-name" class="form-control" placeholder="Nombre" required></div>
-            <div class="col-md-5"><input type="email" id="user-email" class="form-control" placeholder="Email" required></div>
-            <div class="col-12"><button class="btn btn-primary" type="submit">Agregar</button></div>
+        <div class="mt-3">
+            <button id="new-user-btn" class="btn btn-primary me-2" type="button">Nuevo usuario</button>
+            <button id="edit-user-btn" class="btn btn-secondary me-2" type="button">Editar usuario</button>
+            <button id="show-user-btn" class="btn btn-info" type="button">Mostrar usuario</button>
+        </div>
+        <form id="new-user-form" class="mt-3 d-none">
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <label for="nombre" class="form-label">Nombre completo</label>
+                    <input type="text" id="nombre" class="form-control" required>
+                </div>
+                <div class="col-md-6">
+                    <label for="correo" class="form-label">Correo</label>
+                    <input type="email" id="correo" class="form-control" required>
+                </div>
+                <div class="col-md-6">
+                    <label for="contrasena" class="form-label">Contraseña</label>
+                    <input type="password" id="contrasena" class="form-control" required>
+                </div>
+                <div class="col-md-6">
+                    <label for="confirmar" class="form-label">Confirmar contraseña</label>
+                    <input type="password" id="confirmar" class="form-control" required>
+                </div>
+                <div class="col-md-6">
+                    <label for="telefono" class="form-label">Teléfono (opcional)</label>
+                    <input type="tel" id="telefono" class="form-control">
+                </div>
+                <div class="col-md-6">
+                    <label for="region" class="form-label">Región</label>
+                    <select id="region" class="form-select" required>
+                        <option value="" selected disabled>Seleccione una región</option>
+                    </select>
+                </div>
+                <div class="col-md-6">
+                    <label for="comuna" class="form-label">Comuna</label>
+                    <select id="comuna" class="form-select" required>
+                        <option value="" selected disabled>Seleccione una comuna</option>
+                    </select>
+                </div>
+                <div class="col-12">
+                    <button type="submit" class="btn btn-success">Guardar usuario</button>
+                </div>
+            </div>
         </form>
     </main>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <script>
-    document.getElementById('user-form').addEventListener('submit', function(e) {
-        e.preventDefault();
-        const table = document.getElementById('user-table');
-        const id = document.getElementById('user-id').value;
-        const name = document.getElementById('user-name').value;
-        const email = document.getElementById('user-email').value;
-        const row = document.createElement('tr');
-        row.innerHTML = `<td>${id}</td><td>${name}</td><td>${email}</td>`;
-        table.appendChild(row);
-        this.reset();
+    document.getElementById('new-user-btn').addEventListener('click', function() {
+        document.getElementById('new-user-form').classList.toggle('d-none');
     });
 </script>
 </body>


### PR DESCRIPTION
## Resumen
- Se agregó columna de stock con valores aleatorios y botones de edición, agregado y visualización de productos.
- Se incorporaron botones para nuevo, editar y mostrar usuario, además de un formulario de nuevo usuario similar al de registro.
- Se eliminaron los formularios antiguos de agregar producto y usuario.

## Pruebas
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b99f8a339c8326b3935c54b7f53a1b